### PR TITLE
Fix dummy link behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@
           <a href="https://facebook.com" class="social-icons__circle" target="_blank" rel="noopener noreferrer">
             <img src="images/social__facebook.svg" alt="Facebook" class="social-icons__image">
           </a>
-          <a href="https://pintrest.com" class="social-icons__circle" target="_blank" rel="noopener noreferrer">
+          <a href="https://pinterest.com" class="social-icons__circle" target="_blank" rel="noopener noreferrer">
             <img src="images/social__pintrest.svg" alt="Pintrest" class="social-icons__image">
           </a>
           <a href="https://plus.google.com" class="social-icons__circle" target="_blank" rel="noopener noreferrer">

--- a/scripts/smooth-scroll.js
+++ b/scripts/smooth-scroll.js
@@ -1,18 +1,32 @@
 (function() {
   var headerHeight = 54;
 
-  function getInnerLinks() {
-    var links = document.getElementsByTagName("a");
-    var innerLinks = [];
-    for (var i = 0; i < links.length; i++) {
-      var href = links[i].getAttribute("href");
-      if (href && href[0] === "#") innerLinks.push(links[i]);
+  function categorizeByHref(anchors) {
+    var result = {
+      external: [],
+      internal: [],
+      dummy: []
+    };
+    var category, href;
+    for (var i = 0; i < anchors.length; i++) {
+      href = anchors[i].getAttribute("href");
+      if (href.startsWith("#")) {
+        if (href === "#") {
+          category = "dummy";
+        } else {
+          category = "internal";
+        }
+      } else {
+        category = "external";
+      }
+      result[category].push(anchors[i]);
     }
-    return innerLinks;
+    return result;
   }
 
-  var innerLinks = getInnerLinks();
-  innerLinks.forEach(function(link) {
+  var categorizedLinks = categorizeByHref(document.getElementsByTagName("a"));
+  console.log(categorizedLinks);
+  categorizedLinks.internal.forEach(function(link) {
     var href = link.getAttribute("href");
     var targetId = href.slice(1);
     var target = document.getElementById(targetId);

--- a/scripts/smooth-scroll.js
+++ b/scripts/smooth-scroll.js
@@ -25,7 +25,6 @@
   }
 
   var categorizedLinks = categorizeByHref(document.getElementsByTagName("a"));
-  console.log(categorizedLinks);
   categorizedLinks.internal.forEach(function(link) {
     var href = link.getAttribute("href");
     var targetId = href.slice(1);

--- a/scripts/smooth-scroll.js
+++ b/scripts/smooth-scroll.js
@@ -24,17 +24,19 @@
     return result;
   }
 
-  var categorizedLinks = categorizeByHref(document.getElementsByTagName("a"));
-  categorizedLinks.internal.forEach(function(link) {
-    var href = link.getAttribute("href");
+  function scrollToTarget(anchor) {
+    var href = anchor.getAttribute("href");
     var targetId = href.slice(1);
     var target = document.getElementById(targetId);
-    link.addEventListener("click", function(e) {
+    anchor.addEventListener("click", function(e) {
       e.preventDefault();
       window.scrollTo({
         top: target.offsetTop - headerHeight,
         behavior: "smooth"
       });
     });
-  });
+  }
+
+  var anchors = categorizeByHref(document.getElementsByTagName("a"));
+  anchors.internal.forEach(scrollToTarget);
 })();

--- a/scripts/smooth-scroll.js
+++ b/scripts/smooth-scroll.js
@@ -37,6 +37,15 @@
     });
   }
 
+  function preventDefault(event) {
+    event.preventDefault();
+  }
+
+  function disableAnchor(anchor) {
+    anchor.onclick = preventDefault;
+  }
+
   var anchors = categorizeByHref(document.getElementsByTagName("a"));
   anchors.internal.forEach(scrollToTarget);
+  anchors.dummy.forEach(disableAnchor);
 })();


### PR DESCRIPTION
Previously, links with href="#" were picked up by the script responsible for scrolling to sections, and an error was printed to the console when they were clicked. Now they are completely inactivated.